### PR TITLE
feat: Escribir los detalles de las tareas creadas

### DIFF
--- a/commands/crearTarea.js
+++ b/commands/crearTarea.js
@@ -81,40 +81,33 @@ module.exports = {
       })
       .flat();
 
-    const embeddedFields = orderedFields
-      .map((data) => {
-        return [
-          ...Object.keys(data).map((key) => {
-            return {
-              name: fileHeaders.find(
-                (header) => Object.values(header)[0] === key
-              ).title,
-              value: `${data[key] || "-"}`,
-              inline: true,
-            };
-          }),
-        ];
-      })
-      .flat();
+    const embeddedMessages = result.map((field, index) => {
+      const embeddedTask = Object.keys(orderedFields[index])
+        .map((key) => {
+          return {
+            name: fileHeaders.find((header) => Object.values(header)[0] === key)
+              .title,
+            value: `${field[key] || "-"}`,
+            inline: true,
+          };
+        })
+        .flat();
 
-    const tasksDescriptions = result
-      .map((data, index) => {
-        return `[${data.id}] ${data.description}${
-          index !== result.length - 1 ? "\n" : ""
-        }`;
-      })
-      .join("");
+      const taskDescription = `[${field.id}] ${field.description}`;
 
-    const embeddedMessage = new EmbedBuilder()
-      .setColor(0x0099ff)
-      .setAuthor({
-        name: `ℹ️  Se creó un nuevo registro en la tabla ${files[0].toLowerCase()}`,
-        iconURL: interaction.user.displayAvatarURL(),
-      })
-      .setTitle(tasksDescriptions)
-      .addFields(embeddedFields)
-      .setTimestamp();
+      const embeddedMessage = new EmbedBuilder()
+        .setColor(0x0099ff)
+        .setAuthor({
+          name: `ℹ️  Se creó un nuevo registro en la tabla ${files[0].toLowerCase()}`,
+          iconURL: interaction.user.displayAvatarURL(),
+        })
+        .setTitle(taskDescription)
+        .addFields(embeddedTask)
+        .setTimestamp();
 
-    await interaction.reply({ embeds: [embeddedMessage] });
+      return embeddedMessage;
+    });
+
+    await interaction.reply({ embeds: [...embeddedMessages] });
   },
 };

--- a/utils/writeCsv.js
+++ b/utils/writeCsv.js
@@ -33,6 +33,9 @@ function getHeader(filename) {
 
 module.exports = {
   files: Files,
+  headers: (filename) => {
+    return getHeader(filename);
+  },
   writeCsv: async ({ filename, data }) => {
     const csvWriter = createCsvWriter({
       path: `./documentos/${filename}.csv`,
@@ -56,8 +59,8 @@ module.exports = {
       data = data.map((_data) => {
         maxId++;
         return {
-          ..._data,
           id: maxId,
+          ..._data,
         };
       });
     }
@@ -65,12 +68,18 @@ module.exports = {
     return csvWriter
       .writeRecords(data)
       .then(() => {
-        console.log(`✔ Se crearon nuevos registros en la tabla ${filename.toLowerCase()}`, data);
-        return `✔ Se crearon nuevos registros en la tabla ${filename.toLowerCase()}`;
+        console.log(
+          `✔ Se crearon nuevos registros en la tabla ${filename.toLowerCase()}\n`,
+          data
+        );
+        return data;
       })
       .catch((error) => {
-        console.error(error);
-        return `No fue posible crear nuevos registros en la tabla ${filename.toLowerCase()} ☹️`;
+        console.error(
+          `No fue posible crear nuevos registros en la tabla ${filename.toLowerCase()} ☹️\n`,
+          error
+        );
+        return false;
       });
   },
 };


### PR DESCRIPTION
### Detalles
- Se modifica la respuesta del bot al momento de crear tareas mediante /crear-tarea

<img width="433" alt="Captura de pantalla 2022-11-08 a la(s) 20 37 16" src="https://user-images.githubusercontent.com/37857113/200699394-f055f550-0bc2-40a1-a388-17d4e7b59da0.png">

### Novedades
- Se refactorizó el util `writeCsv.js` para que devuelva el resultado de la escritura de datos en lugar de un string y también se exportan los listados de archivos que existen con sus respectivos encabezados.
- El comando ahora responde un bloque detallado sobre la tarea creada en lugar de un simple mensaje de texto

### Capturas de pantalla

<img width="869" alt="Captura de pantalla 2022-11-08 a la(s) 20 36 54" src="https://user-images.githubusercontent.com/37857113/200700368-feb94e9f-0d0f-49af-99e0-52f314371277.png">
