### PR TITLE
feat: Listar tareas

### DIFF
--- a/commands/ver-tareas.js
+++ b/commands/ver-tareas.js
@@ -1,0 +1,100 @@
+const { SlashCommandBuilder, EmbedBuilder } = require("discord.js");
+const getTasks = require("../utils/getTasks");
+const { files } = require("../utils/writeCsv");
+
+new SlashCommandBuilder();
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName("ver-tareas")
+    .setDescription("Mostrar las tareas pendientes")
+    .addIntegerOption((option) =>
+      option
+        .setName("cantidad")
+        .setDescription("Cantidad elementos a mostrar")
+        .setRequired(false)
+        .setMinValue(1)
+    )
+    .addUserOption((option) =>
+      option
+        .setName("responsable")
+        .setDescription("Filtrar según responsable")
+        .setRequired(false)
+    )
+    .addStringOption((option) =>
+      option
+        .setName("ordenar")
+        .setDescription("Elegí un criterio de ordenamiento")
+        .setRequired(false)
+        .addChoices(
+          { name: "⬆️ Descripción", value: "description,asc" },
+          { name: "⬇️ Descripción", value: "description,desc" },
+          { name: "⬆️ Tipo", value: "type,asc" },
+          { name: "⬇️ Tipo", value: "type,desc" },
+          { name: "⬆️ Fecha de creación", value: "createdAt,asc" },
+          { name: "⬇️ Fecha de creación", value: "createdAt,desc" },
+          { name: "⬆️ Fecha de finalización", value: "finishBy,asc" },
+          { name: "⬇️ Fecha de finalización", value: "finishBy,desc" }
+        )
+    ),
+  async execute(interaction) {
+    const cantidad = interaction.options.get("cantidad", false)?.value;
+    const responsable = interaction.options.get("responsable", false);
+    const orderBy = interaction.options.get("ordenar", false)?.value;
+    const filters = {
+      responsible: responsable?.user?.username,
+    };
+
+    let emptyEmbedsMsg = "No hay tareas que cumplan el criterio de búsqueda";
+    let embeds = [];
+
+    console.log("filters data", filters);
+    console.log("order by", orderBy);
+    const tasks = await getTasks(filters, orderBy);
+
+    tasks.forEach((task, index) => {
+      const taskDescription = `[${task.id}] ${task.description}`;
+
+      const obfuscatedColumns = [
+        { id: "createdAt", title: "Fecha de creación" },
+        { id: "type", title: "Tipo" },
+        { id: "responsible", title: "Responsable" },
+        { id: "finishBy", title: "Fecha de finalización" },
+      ];
+
+      const obfuscatedTask = {
+        createdAt: task.createdAt,
+        type: task.type,
+        responsible: task.responsible,
+        finishBy: task.finishBy,
+      };
+
+      const embeddedTask = Object.keys(obfuscatedTask)
+        .map((key, index) => {
+          return {
+            name: obfuscatedColumns[index].title,
+            value: `${task[key] || "-"}`,
+            inline: true,
+          };
+        })
+        .flat();
+
+      const embeddedMessage = new EmbedBuilder()
+        .setColor(0x0099ff)
+        .setTitle(taskDescription)
+        .addFields(embeddedTask)
+        .setTimestamp();
+
+      if (cantidad && index < cantidad) {
+        embeds.push(embeddedMessage);
+      } else if (!cantidad) {
+        embeds.push(embeddedMessage);
+      }
+    });
+
+    await interaction.reply({
+      content: !embeds.length ? emptyEmbedsMsg : "",
+      embeds: embeds,
+      ephemeral: true,
+    });
+  },
+};

--- a/commands/ver-tareas.js
+++ b/commands/ver-tareas.js
@@ -44,7 +44,7 @@ module.exports = {
       responsible: responsable?.user?.username,
     };
 
-    let emptyEmbedsMsg = "No hay tareas que cumplan el criterio de búsqueda";
+    let emptyEmbedsMsg = "No hay tareas que cumplan con el criterio de búsqueda";
     let embeds = [];
 
     console.log("filters data", filters);

--- a/utils/getTasks.js
+++ b/utils/getTasks.js
@@ -1,0 +1,66 @@
+const fs = require("fs");
+const { parse } = require("csv-parse");
+const { files } = require("./writeCsv");
+
+function sortAlphabets(tasks, field, order) {
+  const sortedTasks = [];
+
+  let strings = tasks.map((task) => {
+    return {
+      id: task.id,
+      value: task[field],
+    };
+  });
+
+  strings = strings.sort((a, b) => {
+    return order === "asc"
+      ? a.value?.localeCompare(b.value)
+      : b.value?.localeCompare(a.value);
+  });
+
+  strings.forEach((string) => {
+    const taskMatch = tasks.find((task) => task.id === string.id);
+    sortedTasks.push(taskMatch);
+  });
+
+  return sortedTasks;
+}
+
+module.exports = async function getTasks(filters = { responsible }, orderBy) {
+  let tasks = [];
+
+  const stream = fs
+    .createReadStream(`./documentos/${files[0]}.csv`)
+    .pipe(parse({ delimiter: ",", from_line: 2 }));
+
+  for await (const chunk of stream) {
+    const task = {
+      id: chunk[0],
+      description: chunk[1],
+      type: chunk[2],
+      responsible: chunk[3],
+      createdAt: chunk[4],
+      finishBy: chunk[5],
+    };
+
+    Object.keys(filters).forEach((filter) => {
+      if (task[filter] === filters[filter]) {
+        tasks.push(task);
+      } else if (!filters[filter]) {
+        switch (filter) {
+          case "responsible":
+            tasks.push(task);
+            break;
+        }
+      }
+    });
+  }
+
+  if (orderBy) {
+    const [key, order] = orderBy.split(",");
+    tasks = sortAlphabets(tasks, key, order);
+    return tasks;
+  } else {
+    return tasks;
+  }
+};


### PR DESCRIPTION
### Detalles
- Se agrega el comando /ver-tareas para listar las tareas en el planning, este listado sólo lo podrá ver el usuario que los solicitó

<img width="864" alt="Captura de pantalla 2022-11-09 a la(s) 01 00 15" src="https://user-images.githubusercontent.com/37857113/200736365-2c9c6662-c5af-43d8-99cd-9dcce35340cb.png">

### Parametros
- **cantidad** - (opcional) - Permite limitar la cantidad de elementos a mostrar
- **responsable** - (opcional) - Permite filtrar la búsqueda de tareas según responsable
- **ordenar** - (opcional) - Permite elegir un criterio de ordenamiento

   - **⬆️/⬇️  Descripción**
   - **⬆️/⬇️  Tipo**
   - **⬆️/⬇️  Fecha de creación**
   - **⬆️/⬇️  Fecha de finalización**

### Novedades
- Se creó el útil `getTasks` para obtener las tareas del planning según responsable y con el parámetro `orderBy` que permite involucrar un criterio de ordenamiento

### Capturas de pantalla

<img width="864" alt="Captura de pantalla 2022-11-09 a la(s) 01 00 52" src="https://user-images.githubusercontent.com/37857113/200736437-93b5e710-87f9-4d86-b655-45f7473d0ba0.png">
<img width="429" alt="Captura de pantalla 2022-11-09 a la(s) 01 02 05" src="https://user-images.githubusercontent.com/37857113/200736451-0e40fedc-3c6b-4c54-abb9-d214c4ef74fe.png">
<img width="867" alt="Captura de pantalla 2022-11-09 a la(s) 01 07 08" src="https://user-images.githubusercontent.com/37857113/200736505-1896910f-f3c7-4399-9cdc-f36af93ba1de.png">
<img width="409" alt="Captura de pantalla 2022-11-09 a la(s) 01 06 40" src="https://user-images.githubusercontent.com/37857113/200736457-71d1092b-d204-4dc0-9511-3423c18a969c.png">

