### PR TITLE
[17] El bot no devuelve el significado de la palabra "PASO". Aumentar cantidad caracteres

### DIFF
--- a/commands/palabra.js
+++ b/commands/palabra.js
@@ -31,6 +31,6 @@ new SlashCommandBuilder()
                 }
                 msg += x.getDefinition();
             });
-            await interaction.reply(msg);
+            await interaction.reply(msg.substring(0, 2000));
         },
     };

--- a/commands/palabradeldia.js
+++ b/commands/palabradeldia.js
@@ -10,6 +10,6 @@ new SlashCommandBuilder()
         async execute(interaction) {
             let msg = await getWOTDMsg();
 
-            await interaction.reply(msg);
+            await interaction.reply(msg.substring(0, 2000));
         },
     };


### PR DESCRIPTION
Se acortó el tamaño del mensaje en las definiciones de palabras de 2000 que es el limite de mensaje de discord