### PR TITLE
Directorios de comandos/ Restringir por rol

### DIFF
--- a/commands/tasks/crearTarea.js
+++ b/commands/tasks/crearTarea.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder } = require("discord.js");
-const { writeCsv, files, headers } = require("../utils/writeCsv");
+const { writeCsv, files, headers } = require("../../utils/writeCsv");
+const { botMasterRole } = require('../../config.json');
 
 new SlashCommandBuilder();
 module.exports = {
@@ -36,6 +37,10 @@ module.exports = {
         .setRequired(false)
     ),
   async execute(interaction) {
+    if(!interaction.member.roles.cache.some(r => r.id === botMasterRole.id)){
+      await interaction.reply({ content: `Necesita rol: ${botMasterRole.name}`, ephemeral: true });
+      return;
+    }
     const descripcion = interaction.options.get("descripcion", true).value;
     const tipo = interaction.options.get("tipo", false)?.value;
     const responsable = interaction.options.get("responsable", false);

--- a/commands/tasks/ver-tareas.js
+++ b/commands/tasks/ver-tareas.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder } = require("discord.js");
-const getTasks = require("../utils/getTasks");
-const { files } = require("../utils/writeCsv");
+const getTasks = require("../../utils/getTasks");
+const { files } = require("../../utils/writeCsv");
 
 new SlashCommandBuilder();
 module.exports = {
@@ -42,10 +42,12 @@ module.exports = {
         )
     ),
   async execute(interaction) {
+    
     const cantidad = interaction.options.get("cantidad", false)?.value;
     const responsable = interaction.options.get("responsable", false);
     const orderBy = interaction.options.get("ordenar", false)?.value;
     const terminadas = interaction.options.get("terminadas", false)?.value;
+    const { botMasterRoleId } = require('../../config.json');
     const filters = {
       responsible: responsable?.user?.username,
     };

--- a/deploy-command.js
+++ b/deploy-command.js
@@ -1,10 +1,10 @@
 const { REST, Routes } = require('discord.js');
 const { clientId, guildId, token } = require('./config.json');
-const fs = require('node:fs');
+const { getCommandFiles } = require('./utils/directoryUtils');
 
 const commands = [];
 // Grab all the command files from the commands directory you created earlier
-const commandFiles = fs.readdirSync('./commands').filter(file => file.endsWith('.js'));
+const commandFiles = getCommandFiles();
 
 // Grab the SlashCommandBuilder#toJSON() output of each command's data for deployment
 for (const file of commandFiles) {

--- a/index.js
+++ b/index.js
@@ -7,13 +7,14 @@ const { RAE } = require('rae-api');
 const checkBirthdays = require('./utils/checkBirthdays.js');
 const getWOTDMsg = require('./utils/raeAPI.js');
 const cron = require('cron');
+const { getCommandFilesIndex } = require('./utils/directoryUtils');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages] });
 client.commands = new Collection();
 const rae = new RAE();
 
 const commandsPath = path.join(__dirname, 'commands');
-const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+const commandFiles = getCommandFilesIndex();
 
 for (const file of commandFiles) {
 	const filePath = path.join(commandsPath, file);

--- a/utils/directoryUtils.js
+++ b/utils/directoryUtils.js
@@ -1,0 +1,34 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+function getDirectories(dir) {
+	return fs.readdirSync(dir).filter(function (file) {
+	  return fs.statSync(dir+'/'+file).isDirectory();
+	});
+}
+
+function getCommandFilesIndex(){
+    const commandsPath = path.join(__dirname, '/../commands');
+    const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+    const subDirectories = getDirectories(commandsPath);
+    const subFiles = [];
+    subDirectories.forEach( x => {
+        fs.readdirSync(`${commandsPath}/${x}`).filter(file => file.endsWith('.js'))
+        .forEach(f => subFiles.push(`/${x}/${f}`)); 
+    });
+    subFiles.forEach(x => commandFiles.push(x));
+    return commandFiles;
+}
+function getCommandFiles(){
+    const commandFiles = fs.readdirSync('./commands').filter(file => file.endsWith('.js'));
+    const subDirectories = getDirectories('./commands');
+    const subFiles = [];
+    subDirectories.forEach( x => {
+        fs.readdirSync(`./commands/${x}`).filter(file => file.endsWith('.js'))
+        .forEach(f => subFiles.push(`/${x}/${f}`)); 
+    });
+    subFiles.forEach(x => commandFiles.push(x));
+    return commandFiles;
+}
+
+module.exports = { getDirectories, getCommandFiles, getCommandFilesIndex };


### PR DESCRIPTION
Se creo el directorio /commands/tasks/ para unificar la locacion de los comandos relacionados a tareas
Se creo directoryUtils.js para unificar la logica de traer los archivos de comandos que se utiliza en index.js y en deploy-command.js
Se cambio la logica en ambos archivos para que use este Utils y tenga en cuenta los directorios internos del directorio de comandos.
Se agrego la verificacion por roleId del usuario emisor del comando para los permisos del comando crear-tarea 